### PR TITLE
fix(auth): move auth checks to server-side to prevent 401 errors

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,54 +3,67 @@ import { FloatingNav } from "@/components/ui/floating-navbar";
 import ThemeSwitch from "@/components/ui/theme-switch";
 import { Home, NotebookPen, FilePlus2, LogIn, LogOut } from "lucide-react";
 import { LogoutLink } from "@kinde-oss/kinde-auth-nextjs/components";
+import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
 
-export default function Header() {
-  const navItems = [
-    {
-      name: "Home",
-      link: "/",
-      icon: <Home className="h-5 w-5" />,
-      requiresAuth: false,
-    },
-    {
-      name: "Blogs",
-      link: "/blogs",
-      icon: <NotebookPen className="h-5 w-5" />,
-      requiresAuth: false,
-    },
-    {
-      name: "Write",
-      link: "/new-blog",
-      icon: <FilePlus2 className="h-5 w-5" />,
-      requiresAuth: true,
-    },
-    {
-      name: "LogIn",
-      link: "/login",
-      icon: <LogIn className="h-5 w-5" />,
-      requiresAuth: false,
-    },
-    {
-      name: "LogOut",
-      requiresAuth: true,
-      useComponent: true,
-      component: (
-        <LogoutLink>
-          <LogOut className="h-5 w-5" />
-        </LogoutLink>
-      ),
-    },
-    {
-      name: "Light",
-      requiresAuth: false,
-      useComponent: true,
-      useDiv: true,
-      component: <ThemeSwitch />,
-    },
-  ];
+export default async function Header() {
+  const session = await getKindeServerSession();
+  const isAuthenticated = await session.isAuthenticated();
+
+  // Filter navItems based on authentication status
+  const filteredNavItems = navItems.filter((navItem) => {
+    const displayNav = navItem.name === "LogOut" ? isAuthenticated : navItem.name === "LogIn" ? !isAuthenticated : !navItem.requiresAuth || (navItem.requiresAuth && isAuthenticated);
+    return displayNav;
+  });
+
+  if (filteredNavItems.length === 0) return null;
+
   return (
     <div className="relative w-full">
-      <FloatingNav navItems={navItems} />
+      <FloatingNav navItems={filteredNavItems} />
     </div>
   );
 }
+
+const navItems = [
+  {
+    name: "Home",
+    link: "/",
+    icon: <Home className="h-5 w-5" />,
+    requiresAuth: false,
+  },
+  {
+    name: "Blogs",
+    link: "/blogs",
+    icon: <NotebookPen className="h-5 w-5" />,
+    requiresAuth: false,
+  },
+  {
+    name: "Write",
+    link: "/new-blog",
+    icon: <FilePlus2 className="h-5 w-5" />,
+    requiresAuth: true,
+  },
+  {
+    name: "LogIn",
+    link: "/login",
+    icon: <LogIn className="h-5 w-5" />,
+    requiresAuth: false,
+  },
+  {
+    name: "LogOut",
+    requiresAuth: true,
+    useComponent: true,
+    component: (
+      <LogoutLink>
+        <LogOut className="h-5 w-5" />
+      </LogoutLink>
+    ),
+  },
+  {
+    name: "Light",
+    requiresAuth: false,
+    useComponent: true,
+    useDiv: true,
+    component: <ThemeSwitch />,
+  },
+];

--- a/src/components/ui/floating-navbar.tsx
+++ b/src/components/ui/floating-navbar.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { cn } from "@/utils/cn";
 import Link from "next/link";
-import { useKindeBrowserClient } from "@kinde-oss/kinde-auth-nextjs";
 
 export const FloatingNav = ({
   navItems,
@@ -20,8 +19,6 @@ export const FloatingNav = ({
   }[];
   className?: string;
 }) => {
-  const { isAuthenticated } = useKindeBrowserClient();
-
   return (
     <div
       className={cn(
@@ -30,10 +27,6 @@ export const FloatingNav = ({
       )}
     >
       {navItems.map((navItem, idx) => {
-        const displayNav = navItem.name === "LogOut" ? isAuthenticated : navItem.name === "LogIn" ? !isAuthenticated : !navItem.requiresAuth || (navItem.requiresAuth && isAuthenticated);
-
-        if (!displayNav) return null;
-
         return (
           <React.Fragment key={`nav-item-${idx}`}>
             {navItem.useComponent ? (


### PR DESCRIPTION
Refactored authentication logic from `FloatingNav` to `Header` component. Replaced `useKindeBrowserClient()` with `getKindeServerSession()` to handle authentication on the server side, avoiding 401 Unauthorized errors on /api/auth/setup